### PR TITLE
Change git hash regex to match abbrevCommit

### DIFF
--- a/_posts/2020-03-01-little-known-features-of-iterm2.markdown
+++ b/_posts/2020-03-01-little-known-features-of-iterm2.markdown
@@ -20,7 +20,7 @@ To make Command-clicking on a commit hash open it in Github, do the following:
 
 1. Install [hub](https://github.com/github/hub)
 2. In your iTerm2 Preferences, go to `Profiles -> Advanced -> Smart Selection -> Edit`
-3. Click the `+` button to add a new rule and set the `Regular Expression` to `[0-9a-f]{8,40}`
+3. Click the `+` button to add a new rule and set the `Regular Expression` to `[0-9a-f]7,40}`
 4. Click on `Edit Actions...` and add a new action
 5. Set the `Action` to `Run Command...`
 6. Set the `Parameter` to `cd "\d" && /usr/local/bin/hub browse -- commit/\0`. You may have to update the path to `hub` here if you installed it to a different directory.


### PR DESCRIPTION
The default hash length of abbrevCommit is 7, so I updated the regex to `[0-9a-f]{7,40}`, I've tested it on my computer and it works